### PR TITLE
:zap: only run docs for one python version, save only once

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.11"]
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
@@ -36,7 +36,7 @@ jobs:
             cd docs
             sphinx-build -n --keep-going -b html ./ ./_build/
       - name: save artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: Sphinx_${{ matrix.python-version }}
           path: docs/_build/


### PR DESCRIPTION
- could be not saved at at to save more storage