### PR TITLE
:sparkles: Preserve species names for folder: A._species stays A. species (and not A)

### DIFF
--- a/src/vuegen/config_manager.py
+++ b/src/vuegen/config_manager.py
@@ -81,18 +81,19 @@ class ConfigManager:
         self.logger = logger
         self.max_depth = max_depth
 
-    def _create_title_fromdir(self, file_dirname: str, is_dir: bool = False) -> str:
+    def create_title(self, name: str, is_dir: bool = False) -> str:
         """
-        Infers title from a file or directory, removing leading numeric prefixes.
+        Infers a title from a file or directory name, removing leading numeric
+        prefixes.
 
         Parameters
         ----------
-        file_dirname : str
+        name : str
             The file or directory name to infer the title from.
         is_dir : bool, optional
             Whether the name belongs to a directory. Directory names have no
             extension, so nothing is stripped after a dot (e.g. ``Test._Species``
-            stays ``Test Species`` instead of becoming ``Test``).
+            stays ``Test. Species`` instead of becoming ``Test``).
             The default is False, i.e. the name is treated as a file name.
 
         Returns
@@ -101,7 +102,7 @@ class ConfigManager:
             A title generated from the file or directory name.
         """
         # Only file names carry an extension which should not end up in the title
-        name = file_dirname if is_dir else os.path.splitext(file_dirname)[0]
+        name = name if is_dir else os.path.splitext(name)[0]
         # Remove leading numbers and underscores if they exist. Any other dot is
         # kept, as it can be part of the name, e.g. an abbreviation.
         _, title = split_numprefix(name)
@@ -126,7 +127,7 @@ class ConfigManager:
         component_config = {}
 
         # Add title, file path, and description
-        component_config["title"] = self._create_title_fromdir(file_path.name)
+        component_config["title"] = self.create_title(file_path.name)
         component_config["file_path"] = (
             file_path.resolve().as_posix()
         )  # ! needs to be posix for all OS support
@@ -345,7 +346,7 @@ class ConfigManager:
                 components.extend(nested_components["components"])
 
         subsection_config = {
-            "title": self._create_title_fromdir(subsection_dir_path.name, is_dir=True),
+            "title": self.create_title(subsection_dir_path.name, is_dir=True),
             "description": self._read_description_file(subsection_dir_path),
             "components": components,
         }
@@ -395,7 +396,7 @@ class ConfigManager:
                     components.append(component_config)
 
         section_config = {
-            "title": self._create_title_fromdir(section_dir_path.name, is_dir=True),
+            "title": self.create_title(section_dir_path.name, is_dir=True),
             "description": self._read_description_file(section_dir_path),
             "subsections": subsections,
             "components": components,
@@ -426,7 +427,7 @@ class ConfigManager:
         yaml_config = {
             "report": {
                 # This will be used for the home section of a report
-                "title": self._create_title_fromdir(base_dir_path.name, is_dir=True),
+                "title": self.create_title(base_dir_path.name, is_dir=True),
                 "description": self._read_description_file(base_dir_path),
                 "graphical_abstract": self._read_home_image_file(base_dir_path),
                 "logo": "",
@@ -438,7 +439,7 @@ class ConfigManager:
         sorted_sections = self._sort_paths_by_numprefix(list(base_dir_path.iterdir()))
 
         main_section_config = {
-            "title": self._create_title_fromdir(base_dir_path.name, is_dir=True),
+            "title": self.create_title(base_dir_path.name, is_dir=True),
             "description": "",
             "components": [],
         }

--- a/src/vuegen/config_manager.py
+++ b/src/vuegen/config_manager.py
@@ -32,6 +32,30 @@ def is_description_file(file_path: Path) -> bool:
     return file_path.name.lower() == DESCRIPTION_FILE_NAME
 
 
+def split_numprefix(name: str) -> tuple[int | None, str]:
+    """
+    Splits a leading numbering prefix from a file or directory name. The prefix
+    can be written with or without a trailing dot, i.e. both ``1_Section`` and
+    ``1._Section`` are recognized.
+
+    Parameters
+    ----------
+    name : str
+        The file or directory name to split.
+
+    Returns
+    -------
+    tuple[int | None, str]
+        The number of the prefix (None if the name has no numbering prefix) and
+        the name without the prefix (the full name if there is no prefix).
+    """
+    prefix, sep, rest = name.partition("_")
+    number = prefix.rstrip(".")
+    if sep and number.isdigit():
+        return int(number), rest
+    return None, name
+
+
 class ConfigManager:
     """
     Class for handling metadata of reports from YAML config file and creating report
@@ -57,7 +81,7 @@ class ConfigManager:
         self.logger = logger
         self.max_depth = max_depth
 
-    def _create_title_fromdir(self, file_dirname: str) -> str:
+    def _create_title_fromdir(self, file_dirname: str, is_dir: bool = False) -> str:
         """
         Infers title from a file or directory, removing leading numeric prefixes.
 
@@ -65,16 +89,22 @@ class ConfigManager:
         ----------
         file_dirname : str
             The file or directory name to infer the title from.
+        is_dir : bool, optional
+            Whether the name belongs to a directory. Directory names have no
+            extension, so nothing is stripped after a dot (e.g. ``Test._Species``
+            stays ``Test Species`` instead of becoming ``Test``).
+            The default is False, i.e. the name is treated as a file name.
 
         Returns
         -------
         str
             A title generated from the file or directory name.
         """
-        # Remove leading numbers and underscores if they exist
-        name = os.path.splitext(file_dirname)[0]
-        parts = name.split("_", 1)
-        title = parts[1] if parts[0].isdigit() and len(parts) > 1 else name
+        # Only file names carry an extension which should not end up in the title
+        name = file_dirname if is_dir else os.path.splitext(file_dirname)[0]
+        # Remove leading numbers and underscores if they exist. Any other dot is
+        # kept, as it can be part of the name, e.g. an abbreviation.
+        _, title = split_numprefix(name)
         return title.replace("_", " ").title()
 
     def _create_component_config_fromfile(self, file_path: Path) -> dict[str, str]:
@@ -205,13 +235,11 @@ class ConfigManager:
         """
 
         def get_sort_key(path: Path) -> tuple:
-            parts = path.name.split("_", 1)
-            if parts[0].isdigit():
-                numeric_prefix = int(parts[0])
-            else:
+            number, _ = split_numprefix(path.name)
+            if number is None:
                 # Non-numeric prefixes go to the end
-                numeric_prefix = float("inf")
-            return numeric_prefix, path.name.lower()
+                number = float("inf")
+            return number, path.name.lower()
 
         return sorted(paths, key=get_sort_key)
 
@@ -317,7 +345,7 @@ class ConfigManager:
                 components.extend(nested_components["components"])
 
         subsection_config = {
-            "title": self._create_title_fromdir(subsection_dir_path.name),
+            "title": self._create_title_fromdir(subsection_dir_path.name, is_dir=True),
             "description": self._read_description_file(subsection_dir_path),
             "components": components,
         }
@@ -367,7 +395,7 @@ class ConfigManager:
                     components.append(component_config)
 
         section_config = {
-            "title": self._create_title_fromdir(section_dir_path.name),
+            "title": self._create_title_fromdir(section_dir_path.name, is_dir=True),
             "description": self._read_description_file(section_dir_path),
             "subsections": subsections,
             "components": components,
@@ -398,7 +426,7 @@ class ConfigManager:
         yaml_config = {
             "report": {
                 # This will be used for the home section of a report
-                "title": self._create_title_fromdir(base_dir_path.name),
+                "title": self._create_title_fromdir(base_dir_path.name, is_dir=True),
                 "description": self._read_description_file(base_dir_path),
                 "graphical_abstract": self._read_home_image_file(base_dir_path),
                 "logo": "",
@@ -410,7 +438,7 @@ class ConfigManager:
         sorted_sections = self._sort_paths_by_numprefix(list(base_dir_path.iterdir()))
 
         main_section_config = {
-            "title": self._create_title_fromdir(base_dir_path.name),
+            "title": self._create_title_fromdir(base_dir_path.name, is_dir=True),
             "description": "",
             "components": [],
         }

--- a/src/vuegen/config_manager.py
+++ b/src/vuegen/config_manager.py
@@ -81,7 +81,7 @@ class ConfigManager:
         self.logger = logger
         self.max_depth = max_depth
 
-    def create_title(self, name: str, is_dir: bool = False) -> str:
+    def _create_title(self, name: str, is_dir: bool = False) -> str:
         """
         Infers a title from a file or directory name, removing leading numeric
         prefixes.
@@ -127,7 +127,7 @@ class ConfigManager:
         component_config = {}
 
         # Add title, file path, and description
-        component_config["title"] = self.create_title(file_path.name)
+        component_config["title"] = self._create_title(file_path.name)
         component_config["file_path"] = (
             file_path.resolve().as_posix()
         )  # ! needs to be posix for all OS support
@@ -346,7 +346,7 @@ class ConfigManager:
                 components.extend(nested_components["components"])
 
         subsection_config = {
-            "title": self.create_title(subsection_dir_path.name, is_dir=True),
+            "title": self._create_title(subsection_dir_path.name, is_dir=True),
             "description": self._read_description_file(subsection_dir_path),
             "components": components,
         }
@@ -396,7 +396,7 @@ class ConfigManager:
                     components.append(component_config)
 
         section_config = {
-            "title": self.create_title(section_dir_path.name, is_dir=True),
+            "title": self._create_title(section_dir_path.name, is_dir=True),
             "description": self._read_description_file(section_dir_path),
             "subsections": subsections,
             "components": components,
@@ -427,7 +427,7 @@ class ConfigManager:
         yaml_config = {
             "report": {
                 # This will be used for the home section of a report
-                "title": self.create_title(base_dir_path.name, is_dir=True),
+                "title": self._create_title(base_dir_path.name, is_dir=True),
                 "description": self._read_description_file(base_dir_path),
                 "graphical_abstract": self._read_home_image_file(base_dir_path),
                 "logo": "",
@@ -439,7 +439,7 @@ class ConfigManager:
         sorted_sections = self._sort_paths_by_numprefix(list(base_dir_path.iterdir()))
 
         main_section_config = {
-            "title": self.create_title(base_dir_path.name, is_dir=True),
+            "title": self._create_title(base_dir_path.name, is_dir=True),
             "description": "",
             "components": [],
         }

--- a/tests/test_config_manager.py
+++ b/tests/test_config_manager.py
@@ -1,15 +1,15 @@
 from vuegen.config_manager import ConfigManager
 
 
-def test_create_title_fromdir_keeps_dots_in_folder_names():
+def test_create_title_keeps_dots_in_folder_names():
     cm = ConfigManager()
     # Folder names have no extension, so nothing after a dot may be stripped
     # A dot within the name is kept, it can be part of the name (abbreviation)
-    assert cm._create_title_fromdir("Test._Species", is_dir=True) == "Test. Species"
-    assert cm._create_title_fromdir("1._Species", is_dir=True) == "Species"
-    assert cm._create_title_fromdir("v1.2_results", is_dir=True) == "V1.2 Results"
+    assert cm._create_title("Test._Species", is_dir=True) == "Test. Species"
+    assert cm._create_title("1._Species", is_dir=True) == "Species"
+    assert cm._create_title("v1.2_results", is_dir=True) == "V1.2 Results"
     # File names still lose their extension
-    assert cm._create_title_fromdir("1_my_table.csv") == "My Table"
+    assert cm._create_title("1_my_table.csv") == "My Table"
 
 
 def test_create_yamlconfig_fromdir_keeps_dots_in_folder_names(tmp_path):

--- a/tests/test_config_manager.py
+++ b/tests/test_config_manager.py
@@ -1,0 +1,29 @@
+from vuegen.config_manager import ConfigManager
+
+
+def test_create_title_fromdir_keeps_dots_in_folder_names():
+    cm = ConfigManager()
+    # Folder names have no extension, so nothing after a dot may be stripped
+    # A dot within the name is kept, it can be part of the name (abbreviation)
+    assert cm._create_title_fromdir("Test._Species", is_dir=True) == "Test. Species"
+    assert cm._create_title_fromdir("1._Species", is_dir=True) == "Species"
+    assert cm._create_title_fromdir("v1.2_results", is_dir=True) == "V1.2 Results"
+    # File names still lose their extension
+    assert cm._create_title_fromdir("1_my_table.csv") == "My Table"
+
+
+def test_create_yamlconfig_fromdir_keeps_dots_in_folder_names(tmp_path):
+    base_dir = tmp_path / "My.Report"
+    section_dir = base_dir / "1._Test._Species"
+    subsection_dir = section_dir / "2._Sub.Section"
+    subsection_dir.mkdir(parents=True)
+    (subsection_dir / "1_my_table.csv").write_text("a,b\n1,2\n")
+
+    config, _ = ConfigManager().create_yamlconfig_fromdir(str(base_dir))
+
+    assert config["report"]["title"] == "My.Report"
+    (section,) = config["sections"]
+    assert section["title"] == "Test. Species"
+    (subsection,) = section["subsections"]
+    assert subsection["title"] == "Sub.Section"
+    assert [c["title"] for c in subsection["components"]] == ["My Table"]


### PR DESCRIPTION
- file extension were always stripped, but folders have not file extension
- very specific to our field

<!--
Please complete the following sections when you submit your pull request. Note that text within html comment tags will not be rendered.
-->
### Summary

<!-- Describe the problem you're trying to fix in this pull request. Please reference any related issue and use fixes/close to automatically close them, if pertinent. For example: "Fixes #58", or "Addresses (but does not close) #238". -->

Fixes #<NUM>

...

### List of changes proposed in this PR (pull-request)

<!-- We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->

* ...
* ...